### PR TITLE
Replace flutter_downloader with file_saver_ffi (server-side)

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -42,39 +42,16 @@
             android:name="flutterEmbedding"
             android:value="2" />
 
-        <!--flutter_downloader-->
+        <!-- File provider for file_saver_ffi
+             This configuration is necessary for file_saver_ffi to be able to open files with the file:// URI -->
         <provider
-            android:name="vn.hunghd.flutterdownloader.DownloadedFileProvider"
-            android:authorities="${applicationId}.flutter_downloader.provider"
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="${applicationId}.file_saver_ffi.fileprovider"
             android:exported="false"
             android:grantUriPermissions="true">
             <meta-data
                 android:name="android.support.FILE_PROVIDER_PATHS"
-                android:resource="@xml/provider_paths"/>
+                android:resource="@xml/file_saver_ffi_file_paths" />
         </provider>
-        <!-- Begin FlutterDownloader customization -->
-        <!-- disable default Initializer -->
-        <provider
-            android:name="androidx.startup.InitializationProvider"
-            android:authorities="${applicationId}.androidx-startup"
-            android:exported="false"
-            tools:node="merge">
-            <meta-data
-                android:name="androidx.work.WorkManagerInitializer"
-                android:value="androidx.startup"
-                tools:node="remove" />
-        </provider>
-        <!-- declare customized Initializer -->
-        <provider
-            android:name="vn.hunghd.flutterdownloader.FlutterDownloaderInitializer"
-            android:authorities="${applicationId}.flutter-downloader-init"
-            android:exported="false">
-            <!-- changes this number to configure the maximum number of concurrent tasks -->
-            <meta-data
-                android:name="vn.hunghd.flutterdownloader.MAX_CONCURRENT_TASKS"
-                android:value="5" />
-        </provider>
-        <!-- End FlutterDownloader customization -->
-
     </application>
 </manifest>

--- a/android/app/src/main/res/xml/file_saver_ffi_file_paths.xml
+++ b/android/app/src/main/res/xml/file_saver_ffi_file_paths.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths>
+    <external-path name="external" path="." />
+</paths>

--- a/lib/ui/server/server_widget.dart
+++ b/lib/ui/server/server_widget.dart
@@ -3,10 +3,12 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:file_picker/file_picker.dart';
+import 'package:file_saver_ffi/file_saver_ffi.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:go_router/go_router.dart';
 import 'package:http_parser/http_parser.dart';
+import 'package:mime/mime.dart';
 import 'package:netshare/config/constants.dart';
 import 'package:netshare/config/styles.dart';
 import 'package:netshare/data/global_scope_data.dart';
@@ -20,9 +22,7 @@ import 'package:netshare/ui/common_view/two_modes_switcher.dart';
 import 'package:netshare/ui/server/qr_popup.dart';
 import 'package:netshare/util/extension.dart';
 import 'package:netshare/util/utility_functions.dart';
-import 'package:mime/mime.dart';
 import 'package:open_dir/open_dir.dart';
-import 'package:open_filex/open_filex.dart';
 import 'package:path/path.dart' as path;
 import 'package:provider/provider.dart';
 import 'package:shelf/shelf.dart';
@@ -534,26 +534,62 @@ class _ServerWidgetState extends State<ServerWidget> {
       await for (final part in parts) {
         final content = part.cast<List<int>>();
 
-        // parse file name from header
-        List<String> pairs =
-            part.headers['content-disposition']?.split(";") ?? [];
-        final fileName = pairs.map((element) {
-          if (element.contains('filename')) {
-            return element.substring(
-                element.indexOf("=") + 2, element.length - 1);
-          }
-          return '';
-        }).firstWhere((element) => element.isNotEmpty);
-        listFileName.add(fileName);
+        // Parse file name from header, then sanitize to prevent path traversal.
+        final contentDisposition = part.headers['content-disposition'] ??
+            part.headers['Content-Disposition'];
+        final rawFileName = (() {
+          final match = RegExp(r'filename="([^"]+)"').firstMatch(
+            contentDisposition ?? '',
+          );
+          return match?.group(1);
+        })();
 
-        // save file to storage
-        final filePath = "${_pickedDir.value.path}/$fileName";
-        IOSink sink = File(filePath).openWrite();
-        await for (List<int> item in content) {
-          sink.add(item);
+        if (rawFileName == null || rawFileName.trim().isEmpty) {
+          continue;
         }
-        await sink.flush();
-        await sink.close();
+
+        final safeFileName = path.basename(rawFileName.trim());
+
+        final baseName = path.basenameWithoutExtension(safeFileName).trim();
+        final ext = path.extension(safeFileName).replaceFirst('.', '').trim();
+
+        final headerMime =
+            part.headers['content-type'] ?? part.headers['Content-Type'];
+        final mimeType = headerMime ??
+            lookupMimeType(safeFileName) ??
+            'application/octet-stream';
+
+        final resolvedBaseName = baseName.isEmpty ? 'file' : baseName;
+        final resolvedExt = ext.isEmpty ? 'bin' : ext;
+        final resolvedFileName =
+            ext.isEmpty ? '$resolvedBaseName.$resolvedExt' : safeFileName;
+
+        // Save file to storage using FileSaver session sink.
+        FileSaverSink? sink;
+        try {
+          sink = await FileSaver.openWrite(
+            fileName: resolvedBaseName,
+            fileType: CustomFileType(ext: resolvedExt, mimeType: mimeType),
+            saveLocation: PathLocation(_pickedDir.value.path),
+            conflictResolution: ConflictResolution.overwrite,
+          );
+
+          if (sink == null) {
+            continue;
+          }
+
+          await sink.addStream(content);
+          await sink.flush();
+          await sink.close();
+          await sink.result;
+        } catch (_) {
+          try {
+            await sink?.cancel();
+          } catch (_) {}
+          rethrow;
+        }
+
+        listFileName.add(resolvedFileName);
       }
 
       // Show dialog for new files.
@@ -681,13 +717,11 @@ class _ServerWidgetState extends State<ServerWidget> {
 
   Future<void> _openFile(String filePath) async {
     try {
-      final result = await OpenFilex.open(filePath);
-      debugPrint('Open file result: ${result.message}');
-      if (result.type != ResultType.done) {
-        if (mounted) {
-          context.showSnackbar('Failed to open file: ${result.message}');
-        }
-      }
+      if (filePath.isEmpty) return;
+
+      final uri = Uri(scheme: "file", path: filePath);
+
+      await FileSaver.openFile(uri);
     } catch (e) {
       debugPrint('Failed to open file: ${e.toString()}');
       if (mounted) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: Data sharing in local network
 
 # The following line prevents the package from being accidentally published to
 # pub.dev using `flutter pub publish`. This is preferred for private packages.
-publish_to: 'none' # Remove this line if you wish to publish to pub.dev
+publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
 # The following defines the version and build number for your application.
 # A version number is three numbers separated by dots, like 1.2.43
@@ -20,7 +20,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 2.2.0+4
 
 environment:
-  sdk: '>=3.0.0 <4.0.0'
+  sdk: ">=3.0.0 <4.0.0"
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions
@@ -31,7 +31,6 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
@@ -53,7 +52,7 @@ dependencies:
   mime: ^1.0.3
   http_parser: ^4.0.2
   share_plus: ^7.1.0
-  flutter_downloader: ^1.11.1
+  file_saver_ffi: ^0.9.0
   path_provider: 2.1.5
   android_path_provider: 0.3.1
   permission_handler: 12.0.1
@@ -96,7 +95,6 @@ dev_dependencies:
 
 # The following section is specific to Flutter packages.
 flutter:
-
   # The following line ensures that the Material Icons font is
   # included with your application, so that you can use the icons in
   # the material Icons class.


### PR DESCRIPTION
> ⚠️ **Please merge #104 first before merging this PR.**
> This PR depends on the `file_saver_ffi` migration introduced there.

## Replace `flutter_downloader` with `file_saver_ffi` (server-side)

Continues the migration from #104, replacing `flutter_downloader` with [`file_saver_ffi`](https://pub.dev/packages/file_saver_ffi) on the server-side receive flow.

### Changes

**`AndroidManifest.xml`**
- Replaced `flutter_downloader`'s `DownloadedFileProvider`, `InitializationProvider`, and `FlutterDownloaderInitializer` with `file_saver_ffi`'s standard `FileProvider`

**`file_saver_ffi_file_paths.xml`** _(new)_
- FileProvider path config required by `file_saver_ffi`

**`server_widget.dart`**
- Replaced raw `File(...).openWrite()` with `FileSaver.openWrite()` + `FileSaverSink`
- Improved `content-disposition` parsing via regex — more robust than previous string splitting
- Added `path.basename()` sanitization to prevent path traversal attacks
- MIME type resolved from `content-type` header, falling back to `lookupMimeType()`
- Replaced `OpenFilex.open()` with `FileSaver.openFile()` — removes `open_filex` dependency
